### PR TITLE
LP-2020427: store SNAP_INSTANCE_NAME in the heap

### DIFF
--- a/snap-preload.c
+++ b/snap-preload.c
@@ -22,8 +22,6 @@ static int (*orig_shm_unlink)(const char *name);
 static char *SNAP_INSTANCE_NAME = NULL;
 static int DEBUG = 0;
 
-#define SNAP_INSTANCE_NAME_MAX_LEN 127
-
 #define SAVE_ORIGINAL_SYMBOL(SYM) orig_##SYM = dlsym(RTLD_NEXT, #SYM)
 
 #define log(FORMAT, ...) if (DEBUG) {fprintf(stderr, "snap-preload: " FORMAT "\n", ##__VA_ARGS__);}
@@ -85,24 +83,18 @@ static void __attribute__ ((constructor)) init(void) {
   SAVE_ORIGINAL_SYMBOL(shm_open);
   SAVE_ORIGINAL_SYMBOL(shm_unlink);
 
-  // Store the snap instance name in the heap because of https://bugs.launchpad.net/maas/+bug/2020427
-  SNAP_INSTANCE_NAME = malloc(SNAP_INSTANCE_NAME_MAX_LEN + 1);
-  if (SNAP_INSTANCE_NAME == NULL) {
-      log("Failed to allocate memory for SNAP_INSTANCE_NAME");
-      return;
-  }
-
   char *env_value = secure_getenv("SNAP_INSTANCE_NAME");
   if (env_value == NULL){
     log("SNAP_INSTANCE_NAME is empty");
     return;
   }
 
-  int env_value_len = strlen(env_value);
-  if (env_value_len > SNAP_INSTANCE_NAME_MAX_LEN) {
-      log("SNAP_INSTANCE_NAME exceeds maximum length of %d chars", SNAP_INSTANCE_NAME_MAX_LEN);
+  // Store the snap instance name in the heap because of https://bugs.launchpad.net/maas/+bug/2020427
+  SNAP_INSTANCE_NAME = malloc(strlen(env_value));
+  if (SNAP_INSTANCE_NAME == NULL) {
+      log("Failed to allocate memory for SNAP_INSTANCE_NAME");
       return;
   }
 
-  strncpy(SNAP_INSTANCE_NAME, env_value, env_value_len);
+  stpcpy(SNAP_INSTANCE_NAME, env_value);
 }  

--- a/snap-preload.c
+++ b/snap-preload.c
@@ -83,8 +83,8 @@ static void init_snap_instance_name(){
   // Store the snap instance name in the heap because of https://bugs.launchpad.net/maas/+bug/2020427
   SNAP_INSTANCE_NAME = malloc(strlen(env_value));
   if (SNAP_INSTANCE_NAME == NULL) {
-      log("Failed to allocate memory for SNAP_INSTANCE_NAME");
-      return;
+    log("Failed to allocate memory for SNAP_INSTANCE_NAME");
+    return;
   }
 
   stpcpy(SNAP_INSTANCE_NAME, env_value);

--- a/snap-preload.c
+++ b/snap-preload.c
@@ -73,16 +73,7 @@ int shm_unlink(const char *name) {
 }
 
 
-// library init
-static void __attribute__ ((constructor)) init(void) {
-  if (secure_getenv("SNAP_PRELOAD_DEBUG")) {
-    DEBUG = 1;
-  }
-
-  SAVE_ORIGINAL_SYMBOL(setgroups);
-  SAVE_ORIGINAL_SYMBOL(shm_open);
-  SAVE_ORIGINAL_SYMBOL(shm_unlink);
-
+static void init_snap_instance_name(){
   char *env_value = secure_getenv("SNAP_INSTANCE_NAME");
   if (env_value == NULL){
     log("SNAP_INSTANCE_NAME is empty");
@@ -97,4 +88,18 @@ static void __attribute__ ((constructor)) init(void) {
   }
 
   stpcpy(SNAP_INSTANCE_NAME, env_value);
+}
+
+
+// library init
+static void __attribute__ ((constructor)) init(void) {
+  if (secure_getenv("SNAP_PRELOAD_DEBUG")) {
+    DEBUG = 1;
+  }
+
+  SAVE_ORIGINAL_SYMBOL(setgroups);
+  SAVE_ORIGINAL_SYMBOL(shm_open);
+  SAVE_ORIGINAL_SYMBOL(shm_unlink);
+
+  init_snap_instance_name();
 }  

--- a/snap-preload.c
+++ b/snap-preload.c
@@ -105,5 +105,4 @@ static void __attribute__ ((constructor)) init(void) {
   }
 
   strncpy(SNAP_INSTANCE_NAME, env_value, env_value_len);
-  SNAP_INSTANCE_NAME[env_value_len] = '\0';
 }  


### PR DESCRIPTION
This PR aims to store the SNAP_INSTANCE_NAME in the heap so to fix the bug described here https://bugs.launchpad.net/maas/+bug/2020427