### PR TITLE
Add sem_open/sem_unlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Currently the library overrides the following functions:
 - `initgroups` and `setgroups` to no-op
 - `shm_open` and `shm_unlink` to prefix the name with
   `snap.$SNAP_INSTANCE_NAME.`, as required by snaps
+- `sem_open` and `sem_unlink`, also fixes the names
 
 
 ## Manual install


### PR DESCRIPTION
the LibC way of creating a semaphore with `sem_open()` is:

 1. create a regular tempfile under `/dev/shm`
 2. initialise the semaphore
 3. write it to the tempfile
 4. hardlink the tempfile to the requested name
 5. unlink the tempfile

due to the snap confinement the first step fails, as the AppArmor profile requires that all files under `/dev/shm` should be named as `snap.$SNAP_NAME.$FILENAME`.

fixes LP#1953049